### PR TITLE
Prefix null fix

### DIFF
--- a/Contents/Sketch/library/common.js
+++ b/Contents/Sketch/library/common.js
@@ -119,6 +119,10 @@ com.geertwille = {
 
             version = this.copyLayerWithFactor(slice, factor);
 
+            if (prefix == null) {
+                prefix = ''
+            }
+
             // If we place the assets in the res folder don't place it in an assets/android folder
             if (this.baseDir.indexOf('/res') > -1 && this.type == "android") {
                 fileName = this.baseDir + "/" + name + "/" + prefix + sliceName + suffix + ".png";


### PR DESCRIPTION
If prefix is not given while exporting to Android and target folder is chosen as res folder. "null" is prefixed to files exported. But not anymore :)