### PR TITLE
Add support for Windows Phone 8.1 (WinRT)

### DIFF
--- a/sketch-export-assets.sketchplugin/Contents/Sketch/Export WinRT Assets.sketchscript
+++ b/sketch-export-assets.sketchplugin/Contents/Sketch/Export WinRT Assets.sketchscript
@@ -1,0 +1,36 @@
+// Developer: Wouter Horre
+// Merged assets generation for Android, windows phone and iOS devices
+@import 'library/common.js'
+
+var document;
+var onRun = function(context) {
+    var selection = context.selection,
+        document = context.document,
+        factors = [
+            {
+                folder: '',
+                scale: 1.0,
+                suffix: '.scale-100',
+            },
+            {
+                folder: '',
+                scale: 1.4,
+                suffix: '.scale-140',
+            },
+            {
+                folder: '',
+                scale: 2.4,
+                suffix: '.scale-240',
+            },
+        ]
+    ;
+
+    var home_folder = "/Users/" + NSUserName();
+    new AppSandbox().authorize(home_folder, function() {
+        com.geertwille.context = context;
+        com.geertwille.document = document;
+
+        var config = com.geertwille.readConfig();
+        com.geertwille.export('winrt', factors, document, selection, config['density-scale']);
+    });
+}

--- a/sketch-export-assets.sketchplugin/Contents/Sketch/manifest.json
+++ b/sketch-export-assets.sketchplugin/Contents/Sketch/manifest.json
@@ -32,6 +32,12 @@
                 "identifier": "change-base-density",
                 "shortcut": "ctrl alt shift 4",
                 "script": "Change Base Density.sketchscript"
+            },
+            {
+                "name": "Export WindowsPhone 8.1 (WinRT) Assets",
+                "identifier": "export-assets-winrt",
+                "shortcut": "ctrl alt shift 5",
+                "script": "Export WinRT Assets.sketchscript"
             }
         ],
     "menu":
@@ -41,7 +47,8 @@
                 "export-assets-android",
                 "export-assets-ios",
                 "export-assets-wp",
-                "change-base-density"
+                "change-base-density",
+                "export-assets-winrt"
             ]
         }
 }


### PR DESCRIPTION
Windows Phone 8.1 apps using the Windows Runtime (aka Windows Phone
Store apps) need assets in the following scales:
* 1.0 (suffix .scale-100)
* 1.4 (suffix .scale-140)
* 2.4 (suffix .scale-240)

See https://go.microsoft.com/fwlink/p/?linkid=258743 page 290.